### PR TITLE
Move dogstatsd start into .profile.d script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -50,6 +50,7 @@ mv $DD_AGENT_ROOT/etc/dd-agent/datadog.conf.example $DD_AGENT_CONF
 sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" $DD_AGENT_CONF
 
 # Drop off the runner
-cp $BUILDPACK_DIR/extra/run-dogstatsd.sh $BUILD_DIR/
-chmod +x $BUILD_DIR/run-dogstatsd.sh
+mkdir -p $BUILD_DIR/.profile.d
+cp $BUILDPACK_DIR/extra/run-dogstatsd.sh $BUILD_DIR/.profile.d/
+chmod +x $BUILD_DIR/.profile.d/run-dogstatsd.sh
 topic "Datadog Agent package installed"

--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -14,7 +14,8 @@ else
   exit 1
 fi
 
-# Load our librariy path first when starting up
-export LD_LIBRARY_PATH=/app/.apt/opt/datadog-agent/embedded/lib:$LD_LIBRARY_PATH
-
-exec /app/.apt/opt/datadog-agent/embedded/bin/python /app/.apt/opt/datadog-agent/agent/dogstatsd.py
+(
+  # Load our library path first when starting up
+  export LD_LIBRARY_PATH=/app/.apt/opt/datadog-agent/embedded/lib:$LD_LIBRARY_PATH
+  exec /app/.apt/opt/datadog-agent/embedded/bin/python /app/.apt/opt/datadog-agent/agent/dogstatsd.py start
+)


### PR DESCRIPTION
This should skip needing users of the buildpack to add the extra level of indirection by using a second `Procfile`. Tested my changes and was successfully getting metrics: 

![metric explorer datadog 2014-12-10 15-55-23](https://cloud.githubusercontent.com/assets/2560/5371177/c68b1778-8085-11e4-9b6d-8d1b223a5ae1.png)

As a bonus, the daemon will also start when you `heroku run bash # or a Rails console or anything else`.

Context: [DevCenter article](https://t.co/RxIrEaSnSV) and [tweet](https://twitter.com/bjeanes/status/542534741946159105)
