### PR TITLE
Configure Datadog to log to /tmp/logs/datadog

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -62,8 +62,6 @@ mv $DD_AGENT_ROOT/etc/dd-agent/datadog.conf.example $DD_AGENT_CONF
 # Turn off syslog
 sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" $DD_AGENT_CONF
 
-mkdir -p $DD_LOG_DIR
-
 # Fix log locations
 sed -i -e"s|^.*collector_log_file:.*$|collector_log_file: $DD_LOG_DIR/collector.log|" $DD_AGENT_CONF
 sed -i -e"s|^.*forwarder_log_file:.*$|forwarder_log_file: $DD_LOG_DIR/forwarder.log|" $DD_AGENT_CONF

--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,7 @@ APT_OPTIONS="-o debug::nolocking=true -o Dir::Etc::Trusted=$GPG_KEYRING_FILE -o 
 # Where the Agent is installed & configured
 DD_AGENT_ROOT="$APT_BUILD_DIR"
 DD_AGENT_CONF="$DD_AGENT_ROOT/opt/datadog-agent/agent/datadog.conf"
+DD_LOG_DIR="/tmp/logs/datadog"
 
 # Ensure directories exists
 mkdir -p "$CACHE_DIR"
@@ -60,6 +61,13 @@ mv $DD_AGENT_ROOT/etc/dd-agent/datadog.conf.example $DD_AGENT_CONF
 
 # Turn off syslog
 sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" $DD_AGENT_CONF
+
+mkdir -p $DD_LOG_DIR
+
+# Fix log locations
+sed -i -e"s|^.*collector_log_file:.*$|collector_log_file: $DD_LOG_DIR/collector.log|" $DD_AGENT_CONF
+sed -i -e"s|^.*forwarder_log_file:.*$|forwarder_log_file: $DD_LOG_DIR/forwarder.log|" $DD_AGENT_CONF
+sed -i -e"s|^.*dogstatsd_log_file:.*$|dogstatsd_log_file: $DD_LOG_DIR/dogstatsd.log|" $DD_AGENT_CONF
 
 # Drop off the runner
 mkdir -p $BUILD_DIR/.profile.d

--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -22,5 +22,6 @@ fi
 (
   # Load our library path first when starting up
   export LD_LIBRARY_PATH=/app/.apt/opt/datadog-agent/embedded/lib:$LD_LIBRARY_PATH
+  mkdir -p /tmp/logs/datadog
   exec /app/.apt/opt/datadog-agent/embedded/bin/python /app/.apt/opt/datadog-agent/agent/dogstatsd.py start
 )


### PR DESCRIPTION
This changes the log paths in `datadog.conf` to `/tmp/logs/datadog` and creates the log directory when a dyno starts.

This fixes #7 