### PR TITLE
Add dyno name to host name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Once started, provides a listening port on 8125 for statsd/dotstatsd metrics and
 
 An example using Ruby is [here](https://github.com/miketheman/buildpack-example-ruby).
 
+## Extra configuration
+
+- If `$DATADOG_USE_DYNO_NAME` is set, reporting to datadog will include the dyno
+  name instead of just the application name.
+
+
 ## Todo
 
 Things that have not been tested, tried, figured out.

--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -13,7 +13,12 @@ else
 fi
 
 if [[ $HEROKU_APP_NAME ]]; then
-  sed -i -e "s/^.*hostname:.*$/hostname: ${HEROKU_APP_NAME}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+  if [[ $DATADOG_USE_DYNO_NAME ]]; then
+    hostname=${HEROKU_APP_NAME}.${DYNO}
+  else
+    hostname=${HEROKU_APP_NAME}
+  fi
+  sed -i -e "s/^.*hostname:.*$/hostname: ${hostname}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 else
   echo "HEROKU_APP_NAME environment variable not set. Run: heroku apps:info|grep ===|cut -d' ' -f2"
   exit 1


### PR DESCRIPTION
Optionally adds the dyno name to the hostname reported to Datadog.