### PR TITLE
Don't start datadog agent in run dynos.

### DIFF
--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -14,7 +14,7 @@ else
   exit 1
 fi
 
-RUN_DYNO=$(echo $DYNO | grep '^run')
+RUN_DYNO=$(echo $DYNO | grep '^run\.[0-9]\+')
 
 if [[ -z $RUN_DYNO ]]; then
   (


### PR DESCRIPTION
This removes the broken `DISABLE_DATADOG_AGENT` env var and simply does not run the agent in one-off dynos.

