### PR TITLE
Disable DataDog agent in the proper way

### DIFF
--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [[ $DISABLE_DATADOG_AGENT ]]; then
-  echo "DISABLE_DATADOG_AGENT environment variable is set, not starting the agent."
-  exit 0
-fi
-
 if [[ $DATADOG_API_KEY ]]; then
   sed -i -e "s/^.*api_key:.*$/api_key: ${DATADOG_API_KEY}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 else
@@ -24,10 +19,14 @@ if [[ $DATADOG_HISTOGRAM_PERCENTILES ]]; then
 fi
 
 (
-  # Unset other PYTHONPATH/PYTHONHOME variables before we start
-  unset PYTHONHOME PYTHONPATH
-  # Load our library path first when starting up
-  export LD_LIBRARY_PATH=/app/.apt/opt/datadog-agent/embedded/lib:$LD_LIBRARY_PATH
-  mkdir -p /tmp/logs/datadog
-  exec /app/.apt/opt/datadog-agent/embedded/bin/python /app/.apt/opt/datadog-agent/agent/dogstatsd.py start
+  if [[ $DISABLE_DATADOG_AGENT ]]; then
+    echo "DISABLE_DATADOG_AGENT environment variable is set, not starting the agent."
+  else
+    # Unset other PYTHONPATH/PYTHONHOME variables before we start
+    unset PYTHONHOME PYTHONPATH
+    # Load our library path first when starting up
+    export LD_LIBRARY_PATH=/app/.apt/opt/datadog-agent/embedded/lib:$LD_LIBRARY_PATH
+    mkdir -p /tmp/logs/datadog
+    exec /app/.apt/opt/datadog-agent/embedded/bin/python /app/.apt/opt/datadog-agent/agent/dogstatsd.py start
+  fi
 )


### PR DESCRIPTION
After #8 there is a way to selectively disable agent. 

That approach does not work as expected. Dynos are crashed after this https://github.com/miketheman/heroku-buildpack-datadog/blob/master/extra/run-dogstatsd.sh#L5 line. This is happening because of the ["Dyno crash restart policy"](https://devcenter.heroku.com/articles/dynos#dyno-crash-restart-policy):

> A dyno “crash” represents any event originating with the process running in the dyno that causes the dyno to stop. That includes the process exiting with an exit code of 0 (or any other exit code).

This PR looks like a proper fix