### PR TITLE
Add support for Datadog APM

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ In addition to the environment variables shown above, there are a number of othe
 | DD_HISTOGRAM_PERCENTILES | *Optional.* You can optionally set additional percentiles for your histogram metrics. See [Histogram Percentiles](#histogram-percentiles) below for more information.|
 | DISABLE_DATADOG_AGENT | *Optional.* When set, the Datadog agent and Datadog Trace agent will not be run. |
 | DD_APM_ENABLED | *Optional.* When set, this will start the Datadog Trace agent. |
-| DD_APM_DEBUG | *Optional.* When set, this will enable debug logging. Log information is available by running `heroku logs`. |
 | DD_SERVICE_NAME | *Optional.* While not read directly by the Datadog Trace agent, we highly recommend that you set an environment variable for your service name. See the [Service Name](#service-name) section below for more information. |
 | DD_SERVICE_ENV | *Optional.* The Datadog Trace agent will automatically try to identify your environment by searching for a tag in the form `env:<your environment name>`. If you do not set a tag or wish to override an exsting tag, you can set the environment with this setting. For more information, see the [Datadog Tracing environments] page. |
 

--- a/README.md
+++ b/README.md
@@ -1,58 +1,116 @@
 heroku-buildpack-datadog
 ========================
 
-A [Heroku Buildpack] to add [Datadog] [DogStatsD] relay to any Dyno.
+A [Heroku Buildpack] to add [Datadog] [DogStatsD] and [APM] to any Dyno.
 
 ## Usage
 
-This buildpack is typically used in conjunction with other languages, so is
-most useful with language-specific buildpacks - see [Heroku Language Buildpacks] for more.
+This buildpack collects [DogStatsD] metrics emited by applications and sends them to your Datadog account. To instrument your application, use the language-appropriate [Datadog library] and add the corresponding [Heroku Language Buildpack].
 
-Here are some setup commands to add this buildpack to your project, as well as
-setting the required environment variables:
+The Datadog [APM] currently supports Go, Python, and Ruby (additional languages are on the roadmap). For more information about adding the language specific trace library to your application, please see the [Datadog Tracing Docs]. Note that the Datadog APM is an additional product and may not be included in your account.
+
+### Installation
+
+To add this buildpack to your project, as well as setting the required environment variables:
 
 ```shell
 cd <root of my project>
 
-heroku create # only if this is a new heroku project
-heroku buildpacks:add heroku/ruby # or other language-specific build page needed
-heroku buildpacks:add --index 1 https://github.com/miketheman/heroku-buildpack-datadog.git
-heroku config:set HEROKU_APP_NAME=$(heroku apps:info|grep ===|cut -d' ' -f2)
-heroku config:add DATADOG_API_KEY=<your API key>
+# If this is a new Heroku project
+heroku create
 
+# Add the appropriate language-specific buildpack
+heroku buildpacks:add heroku/ruby
+
+# Add this buildpack and set your environment variables
+heroku buildpacks:add --index 1 https://github.com/miketheman/heroku-buildpack-datadog.git
+heroku config:set DD_HOSTNAME=$(heroku apps:info|grep ===|cut -d' ' -f2)
+heroku config:add DD_API_KEY=<your API key>
+
+# To enable APM tracing, run the following
+heroku config:set DD_APM_ENABLED=true
+
+# Deploy to Heroku
 git push heroku master
 ```
 
-You can create/retrieve the `DATADOG_API_KEY` from your account on [this page](https://app.datadoghq.com/account/settings#api).
-API Key, not application key.
+Once complete, the Datadog agent (and optionally the Datadog APM tracing agent) will be started automatically with the Dyno startup.
 
-You can optionally set additional percentiles for your histogram metrics. By default
-only 95th percentile will be generated. To generate additional percentiles, set *all*
-persentiles, including default one, using env variable `DATADOG_HISTOGRAM_PERCENTILES`.
-For example, if you want to generate 0.95 and 0.99 percentiles, you may use following
-command:
+The Datadog agent provides a listening port on 8125 for statsd/dogstatsd metrics and events. Traces are collected on port 8126 (older Datadog tracing libraries may use port 7777).
+
+### Configuration
+
+In addition to the environment variables shown above, there are a number of others you can set:
+
+| Setting | Description|
+| --- | --- |
+| DD_API_KEY | *Required.* Your API key is available from [the Datadog API Integrations page]. Note that this is the *API* key, not the application key. |
+| DD_HOSTNAME | *Optional.* By default, the Datadog agent will report your Dyno hostname. You may use this setting to override the Dyno hostname. |
+| DD_TAGS | *Optional.* Sets additional tags provided as a comma-delimited string. For example, `heroku config:set DD_TAGS=simple-tag-0,tag-key-1:tag-value-1`. See the ["Guide to tagging"] for more information. |
+| DD_HISTOGRAM_PERCENTILES | *Optional.* You can optionally set additional percentiles for your histogram metrics. See [Histogram Percentiles](#histogram-percentiles) below for more information.|
+| DISABLE_DATADOG_AGENT | *Optional.* When set, the Datadog agent and Datadog Trace agent will not be run. |
+| DD_APM_ENABLED | *Optional.* When set, this will start the Datadog Trace agent. |
+| DD_APM_DEBUG | *Optional.* When set, this will enable debug logging. Log information is available by running `heroku logs`. |
+| DD_SERVICE_NAME | *Optional.* While not read directly by the Datadog Trace agent, we highly recommend that you set an environment variable for your service name. See the [Service Name](#service-name) section below for more information. |
+| DD_SERVICE_ENV | *Optional.* The Datadog Trace agent will automatically try to identify your environment by searching for a tag in the form `env:<your environment name>`. If you do not set a tag or wish to override an exsting tag, you can set the environment with this setting. For more information, see the [Datadog Tracing environments page]. |
+
+### Histogram percentiles
+
+You can optionally set additional percentiles for your histogram metrics. By default only 95th percentile will be generated. To generate additional percentiles, set *all* persentiles, including default one, using env variable `DATADOG_HISTOGRAM_PERCENTILES`.  For example, if you want to generate 0.95 and 0.99 percentiles, you may use following command:
 
 ```shell
 heroku config:add DATADOG_HISTOGRAM_PERCENTILES="0.95, 0.99"
 ```
 
-Documentaion about additional percentiles [here](https://help.datadoghq.com/hc/en-us/articles/204588979-How-to-graph-percentiles-in-Datadog).
+For more information about about additional percentiles, see [the percentiles documentation].
 
-Once complete, the Agent's dogstatsd binary will be started automatically with the Dyno startup.
+### Service name
 
-Once started, provides a listening port on 8125 for statsd/dogstatsd metrics and events.
+A service is a named set of processes that do the same job, such as `webapp` or `database`. The service name provides context when evaluating your trace data.
 
-An example using Ruby is [here](https://github.com/miketheman/buildpack-example-ruby).
+Although the service name is passed to Datadog on the application level, we highly recommend that you set the value as an environment variable, rather than directly in your application code.
+
+For example, set your service name as an environment variable:
+
+```shell
+heroku config:set DD_SERVICE_NAME=my-webapp
+```
+
+Then in a python web application, you could set the service name from the environment variable:
+
+```python
+import os
+from ddtrace import tracer
+
+service_nane = os.environ.get('DD_SERVICE_NAME')
+span = tracer.trace("web.request", service=service_name)
+...
+span.finish()
+```
+
+For Ruby on Rails applications, you'll need to configure the `config/initializers/datadog-tracer.rb` file:
+
+```ruby
+Rails.configuration.datadog_trace = {
+  default_service: ENV['DD_SERVICE_NAME'] || 'my-app',
+}
+```
+
+Setting the service name will vary according to your language or supported framework. Please reference the [Datadog Tracing Integrations] for more information.
+
+For more information about services, see the [Datadog Tracing Terminology page].
+
+### Example
+
+An example using Ruby is available at [https://github.com/miketheman/buildpack-example-ruby].
 
 ## Todo
 
 Things that have not been tested, tried, figured out.
 
 - see if we can bypass apt updates on every run
-- determine how the compiled cache behaves with new releases of the
-  datadog-agent package, as it stored the deb file
-- tag release when stable, update docs on how to use a given release in
-  `.buildpacks`, like "https://github.com/miketheman/heroku-buildpack-datadog.git#v1.0.0"
+- determine how the compiled cache behaves with new releases of the datadog-agent package, as it stored the deb file
+- tag release when stable, update docs on how to use a given release in `.buildpacks`, like "https://github.com/miketheman/heroku-buildpack-datadog.git#v1.0.0"
 
 ## Contributing
 
@@ -64,10 +122,8 @@ Things that have not been tested, tried, figured out.
 
 ## Credits
 
-This buildpack was heavily inspired by the heroku-buildpack-apt code, as well
-as many others from Heroku and [@ddollar].
-We leverage the same type of process runner that the Datadog Docker container
-uses, with a couple of modifications.
+This buildpack was heavily inspired by the heroku-buildpack-apt code, as well as many others from Heroku and [@ddollar].
+We leverage the same type of process runner that the Datadog Docker container uses, with a couple of modifications.
 
 Author: [@miketheman]
 
@@ -75,10 +131,19 @@ Author: [@miketheman]
 
 MIT License, see `LICENSE` file for full text.
 
+[Heroku Buildpack]: https://devcenter.heroku.com/articles/buildpacks
 [Datadog]: http://www.datadog.com
 [DogStatsD]: http://docs.datadoghq.com/guides/dogstatsd/
-[Heroku Buildpack]: https://devcenter.heroku.com/articles/buildpacks
-[Heroku Language Buildpacks]: https://devcenter.heroku.com/articles/buildpacks#default-buildpacks
+[APM]: https://www.datadoghq.com/apm/
+[Datadog library]: http://docs.datadoghq.com/libraries/
+[Heroku Language Buildpack]: https://devcenter.heroku.com/articles/buildpacks#default-buildpacks
+[Datadog Tracing Docs]: https://app.datadoghq.com/trace/docs
+[the Datadog API Integrations page]: https://app.datadoghq.com/account/settings#api
+["Guide to tagging"]: http://docs.datadoghq.com/guides/tagging/
+[Datadog Tracing environments page]: https://app.datadoghq.com/trace/docs/tutorials/environments
+[the percentiles documentation]: https://help.datadoghq.com/hc/en-us/articles/204588979-How-to-graph-percentiles-in-Datadog
+[Datadog Tracing Integrations]: https://app.datadoghq.com/trace/docs/languages
+[Datadog Tracing Terminology page]: https://app.datadoghq.com/trace/docs/tutorials/terminology
 
 [@ddollar]: https://github.com/ddollar
 [@miketheman]: https://github.com/miketheman

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Heroku Buildpack] to add [Datadog] [DogStatsD] and [APM] to any Dyno.
 
 This buildpack collects [DogStatsD] metrics emited by applications and sends them to your Datadog account. To instrument your application, use the language-appropriate [Datadog library] and add the corresponding [Heroku Language Buildpack].
 
-The Datadog [APM] currently supports Go, Python, and Ruby (additional languages are on the roadmap). For more information about adding the language specific trace library to your application, please see the [Datadog Tracing Docs]. Note that the Datadog APM is an additional product and may not be included in your account.
+The Datadog [APM] currently supports Go, Python, and Ruby (additional languages are on the roadmap). For more information about adding the language specific trace library to your application, please see the [Datadog Tracing documentation]. Note that the Datadog APM is an additional product and may not be included in your account.
 
 ### Installation
 
@@ -44,7 +44,7 @@ In addition to the environment variables shown above, there are a number of othe
 
 | Setting | Description|
 | --- | --- |
-| DD_API_KEY | *Required.* Your API key is available from [the Datadog API Integrations page]. Note that this is the *API* key, not the application key. |
+| DD_API_KEY | *Required.* Your API key is available from the [Datadog API integrations] page. Note that this is the *API* key, not the application key. |
 | DD_HOSTNAME | *Optional.* By default, the Datadog agent will report your Dyno hostname. You may use this setting to override the Dyno hostname. |
 | DD_TAGS | *Optional.* Sets additional tags provided as a comma-delimited string. For example, `heroku config:set DD_TAGS=simple-tag-0,tag-key-1:tag-value-1`. See the ["Guide to tagging"] for more information. |
 | DD_HISTOGRAM_PERCENTILES | *Optional.* You can optionally set additional percentiles for your histogram metrics. See [Histogram Percentiles](#histogram-percentiles) below for more information.|
@@ -52,17 +52,17 @@ In addition to the environment variables shown above, there are a number of othe
 | DD_APM_ENABLED | *Optional.* When set, this will start the Datadog Trace agent. |
 | DD_APM_DEBUG | *Optional.* When set, this will enable debug logging. Log information is available by running `heroku logs`. |
 | DD_SERVICE_NAME | *Optional.* While not read directly by the Datadog Trace agent, we highly recommend that you set an environment variable for your service name. See the [Service Name](#service-name) section below for more information. |
-| DD_SERVICE_ENV | *Optional.* The Datadog Trace agent will automatically try to identify your environment by searching for a tag in the form `env:<your environment name>`. If you do not set a tag or wish to override an exsting tag, you can set the environment with this setting. For more information, see the [Datadog Tracing environments page]. |
+| DD_SERVICE_ENV | *Optional.* The Datadog Trace agent will automatically try to identify your environment by searching for a tag in the form `env:<your environment name>`. If you do not set a tag or wish to override an exsting tag, you can set the environment with this setting. For more information, see the [Datadog Tracing environments] page. |
 
 ### Histogram percentiles
 
-You can optionally set additional percentiles for your histogram metrics. By default only 95th percentile will be generated. To generate additional percentiles, set *all* persentiles, including default one, using env variable `DATADOG_HISTOGRAM_PERCENTILES`.  For example, if you want to generate 0.95 and 0.99 percentiles, you may use following command:
+You can optionally set additional percentiles for your histogram metrics. By default only the 95th percentile will be generated. To generate additional percentiles, set *all* percentiles, including the default, using the env variable `DD_HISTOGRAM_PERCENTILES`.  For example, if you want to generate 0.95 and 0.99 percentiles, you may use following command:
 
 ```shell
-heroku config:add DATADOG_HISTOGRAM_PERCENTILES="0.95, 0.99"
+heroku config:add DD_HISTOGRAM_PERCENTILES="0.95, 0.99"
 ```
 
-For more information about about additional percentiles, see [the percentiles documentation].
+For more information about about additional percentiles, see the [percentiles documentation].
 
 ### Service name
 
@@ -96,13 +96,13 @@ Rails.configuration.datadog_trace = {
 }
 ```
 
-Setting the service name will vary according to your language or supported framework. Please reference the [Datadog Tracing Integrations] for more information.
+Setting the service name will vary according to your language or supported framework. Please reference the [Datadog Tracing integrations] page for more information.
 
-For more information about services, see the [Datadog Tracing Terminology page].
+For more information about services, see the [Datadog Tracing terminology] page.
 
 ### Example
 
-An example using Ruby is available at [https://github.com/miketheman/buildpack-example-ruby].
+An example using Ruby is available at https://github.com/miketheman/buildpack-example-ruby.
 
 ## Todo
 
@@ -137,13 +137,13 @@ MIT License, see `LICENSE` file for full text.
 [APM]: https://www.datadoghq.com/apm/
 [Datadog library]: http://docs.datadoghq.com/libraries/
 [Heroku Language Buildpack]: https://devcenter.heroku.com/articles/buildpacks#default-buildpacks
-[Datadog Tracing Docs]: https://app.datadoghq.com/trace/docs
-[the Datadog API Integrations page]: https://app.datadoghq.com/account/settings#api
+[Datadog Tracing documentation]: https://app.datadoghq.com/trace/docs
+[Datadog API integrations]: https://app.datadoghq.com/account/settings#api
 ["Guide to tagging"]: http://docs.datadoghq.com/guides/tagging/
-[Datadog Tracing environments page]: https://app.datadoghq.com/trace/docs/tutorials/environments
-[the percentiles documentation]: https://help.datadoghq.com/hc/en-us/articles/204588979-How-to-graph-percentiles-in-Datadog
-[Datadog Tracing Integrations]: https://app.datadoghq.com/trace/docs/languages
-[Datadog Tracing Terminology page]: https://app.datadoghq.com/trace/docs/tutorials/terminology
+[Datadog Tracing environments]: https://app.datadoghq.com/trace/docs/tutorials/environments
+[percentiles documentation]: https://help.datadoghq.com/hc/en-us/articles/204588979-How-to-graph-percentiles-in-Datadog
+[Datadog Tracing integrations]: https://app.datadoghq.com/trace/docs/languages
+[Datadog Tracing terminology]: https://app.datadoghq.com/trace/docs/tutorials/terminology
 
 [@ddollar]: https://github.com/ddollar
 [@miketheman]: https://github.com/miketheman

--- a/bin/compile
+++ b/bin/compile
@@ -51,11 +51,11 @@ apt-get $APT_OPTIONS update | indent
 topic "Fetching datadog-agent"
 apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommends datadog-agent | indent
 
+# Install the latest agent package.
 topic "Fetching deb packages"
-for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do
-  topic "Installing $(basename $DEB)"
-  dpkg -x $DEB $BUILD_DIR/.apt/
-done
+DEB=$(ls -t $APT_CACHE_DIR/archives/*.deb | head -n 1)
+topic "Installing $(basename $DEB)"
+dpkg -x $DEB $BUILD_DIR/.apt/
 
 mv $DD_AGENT_ROOT/etc/dd-agent/datadog.conf.example $DD_AGENT_CONF
 

--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -1,21 +1,39 @@
 #!/bin/bash
 
-if [[ $DATADOG_API_KEY ]]; then
-  sed -i -e "s/^.*api_key:.*$/api_key: ${DATADOG_API_KEY}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+# Prefered Datadog env var name
+if [[ $DD_API_KEY ]]; then
+  sed -i -e "s/^[# ]*api_key:.*$/api_key: ${DD_API_KEY}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+# Legacy env var support
+elif [[ $DATADOG_API_KEY ]]; then
+  sed -i -e "s/^[# ]*api_key:.*$/api_key: ${DATADOG_API_KEY}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 else
-  echo "DATADOG_API_KEY environment variable not set. Run: heroku config:add DATADOG_API_KEY=<your API key>"
+  echo "DD_API_KEY environment variable not set. Run: heroku config:add DD_API_KEY=<your API key>"
   exit 1
 fi
 
-if [[ $HEROKU_APP_NAME ]]; then
-  sed -i -e "s/^.*hostname:.*$/hostname: ${HEROKU_APP_NAME}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+# Prefered Datadog env var name
+if [[ $DD_HOSTNAME ]]; then
+  sed -i -e "s/^[# ]*hostname:.*$/hostname: ${DD_HOSTNAME}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+# Legacy env var support
+elif [[ $HEROKU_APP_NAME ]]; then
+  sed -i -e "s/^[# ]*hostname:.*$/hostname: ${HEROKU_APP_NAME}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 else
-  echo "HEROKU_APP_NAME environment variable not set. Run: heroku apps:info|grep ===|cut -d' ' -f2"
+  echo "DD_HOSTNAME environment variable not set. Run: heroku config:set DD_HOSTNAME=$(heroku apps:info|grep ===|cut -d' ' -f2)"
   exit 1
 fi
 
-if [[ $DATADOG_HISTOGRAM_PERCENTILES ]]; then
-  sed -i -e "s/^.*histogram_percentiles:.*$/histogram_percentiles: ${DATADOG_HISTOGRAM_PERCENTILES}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+
+if [[ $DD_APM_ENABLED == "true" ]]; then
+  sed -i -e "s/^[# ]*apm_enabled:.*$/apm_enabled: true/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+  echo "apm_enabled: true" >> /app/.apt/opt/datadog-agent/agent/datadog.conf
+fi
+
+# Prefered Datadog env var name
+if [[ $DD_HISTOGRAM_PERCENTILES ]]; then
+  sed -i -e "s/^[# ]*histogram_percentiles:.*$/histogram_percentiles: ${DD_HISTOGRAM_PERCENTILES}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+# Legacy env var support
+elif [[ $DATADOG_HISTOGRAM_PERCENTILES ]]; then
+  sed -i -e "s/^[# ]*histogram_percentiles:.*$/histogram_percentiles: ${DATADOG_HISTOGRAM_PERCENTILES}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 fi
 
 (
@@ -28,5 +46,16 @@ fi
     export LD_LIBRARY_PATH=/app/.apt/opt/datadog-agent/embedded/lib:$LD_LIBRARY_PATH
     mkdir -p /tmp/logs/datadog
     exec /app/.apt/opt/datadog-agent/embedded/bin/python /app/.apt/opt/datadog-agent/agent/dogstatsd.py start
+  fi
+)
+
+(
+  if [[ $DISABLE_DATADOG_AGENT ]]; then
+    echo "DISABLE_DATADOG_AGENT environment variable is set, not starting the tracing agent."
+  else
+    # Enable the trace agent
+    if [[ $DD_APM_ENABLED == "true" ]]; then
+      exec /app/.apt/opt/datadog-agent/bin/trace-agent -ddconfig /app/.apt/opt/datadog-agent/agent/datadog.conf -debug >> /tmp/logs/datadog/trace-agent.log 2>&1 &
+    fi
   fi
 )

--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -56,11 +56,7 @@ fi
   else
     # Enable the trace agent
     if [[ $DD_APM_ENABLED ]]; then
-      if [[ $DD_APM_DEBUG ]]; then
-        exec /app/.apt/opt/datadog-agent/bin/trace-agent -ddconfig /app/.apt/opt/datadog-agent/agent/datadog.conf -debug 2>&1 &
-      else
-        exec /app/.apt/opt/datadog-agent/bin/trace-agent -ddconfig /app/.apt/opt/datadog-agent/agent/datadog.conf >> /tmp/logs/datadog/trace-agent.log 2>&1 &
-      fi
+      exec /app/.apt/opt/datadog-agent/bin/trace-agent -ddconfig /app/.apt/opt/datadog-agent/agent/datadog.conf >> /tmp/logs/datadog/trace-agent.log 2>&1 &
     fi
   fi
 )

--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -37,6 +37,9 @@ elif [[ $DATADOG_HISTOGRAM_PERCENTILES ]]; then
   sed -i -e "s/^[# ]*histogram_percentiles:.*$/histogram_percentiles: ${DATADOG_HISTOGRAM_PERCENTILES}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 fi
 
+# Enable Developer Mode
+sed -i -e "s/^[# ]*developer_mode:.*$/developer_mode: yes/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+
 (
   if [[ $DISABLE_DATADOG_AGENT ]]; then
     echo "DISABLE_DATADOG_AGENT environment variable is set, not starting the agent."

--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -23,8 +23,9 @@ else
 fi
 
 
-if [[ $DD_APM_ENABLED == "true" ]]; then
+if [[ $DD_APM_ENABLED ]]; then
   sed -i -e "s/^[# ]*apm_enabled:.*$/apm_enabled: true/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+  # Doesn't appear to have apm in the conf file. Old agent release?
   echo "apm_enabled: true" >> /app/.apt/opt/datadog-agent/agent/datadog.conf
 fi
 
@@ -54,8 +55,12 @@ fi
     echo "DISABLE_DATADOG_AGENT environment variable is set, not starting the tracing agent."
   else
     # Enable the trace agent
-    if [[ $DD_APM_ENABLED == "true" ]]; then
-      exec /app/.apt/opt/datadog-agent/bin/trace-agent -ddconfig /app/.apt/opt/datadog-agent/agent/datadog.conf -debug >> /tmp/logs/datadog/trace-agent.log 2>&1 &
+    if [[ $DD_APM_ENABLED ]]; then
+      if [[ $DD_APM_DEBUG ]]; then
+        exec /app/.apt/opt/datadog-agent/bin/trace-agent -ddconfig /app/.apt/opt/datadog-agent/agent/datadog.conf -debug 2>&1 &
+      else
+        exec /app/.apt/opt/datadog-agent/bin/trace-agent -ddconfig /app/.apt/opt/datadog-agent/agent/datadog.conf >> /tmp/logs/datadog/trace-agent.log 2>&1 &
+      fi
     fi
   fi
 )


### PR DESCRIPTION
Adds support for the Datadog APM.

- Adds new `DD_APM_ENABLED` env var and kicks off trace agent in `extras/run-dogstatsd.sh`
- Updates env vars for preferred `DD_` styling (used by Datadog libraries and in docs), but maintains support for previous naming as well
- Updates README.md with information about tracing and available env vars.

p.s. - most of this is copied over from work done on https://github.com/Datadog/heroku-buildpack-datadog