### PR TITLE
Pin version to 1:5.11.2-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ heroku-buildpack-datadog
 
 A [Heroku Buildpack] to add [Datadog] [DogStatsD] relay to any Dyno.
 
+## Warning: Version pinned to datadog-agent 1:5.11.2-1
+
+[datadog-agent 5.12.0 broke compatibility with this buildpack
+by hard-deprecating `dogstatsd.py start`](https://github.com/DataDog/dd-agent/pull/3004)
+
+When the incompatibility is resolved [#30](https://github.com/miketheman/heroku-buildpack-datadog/pull/30) can be reverted.
+
 ## Usage
 
 This buildpack is typically used in conjunction with other languages, so is

--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent
 
 topic "Fetching datadog-agent"
-apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommends datadog-agent | indent
+apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommends datadog-agent=5.11.2-1 | indent
 
 topic "Fetching deb packages"
 for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do

--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,8 @@ topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent
 
 topic "Fetching datadog-agent"
-apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommends datadog-agent=5.11.2-1 | indent
+apt-cache $APT_OPTIONS showpkg datadog-agent
+apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommends datadog-agent=1:5.11.2-1 | indent
 
 topic "Fetching deb packages"
 for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do

--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,6 @@ topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent
 
 topic "Fetching datadog-agent"
-apt-cache $APT_OPTIONS showpkg datadog-agent
 apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommends datadog-agent=1:5.11.2-1 | indent
 
 topic "Fetching deb packages"


### PR DESCRIPTION
Refs #29 

5.12.0 which became available in the apt repository is incompatible with master because it hard deprecates `dogstatsd.py start`.

This pins to the latest 5.11.2 so that the agent is able to start.